### PR TITLE
Add support for token based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ To prevent header spoofing, any `X-Authentik-*` headers sent by either the upstr
 
 User sessions are managed using a cookie named like `authentik_proxy_<ID>`. This cookie is set by Authentik during the login flow and is used to identify the session in later requests. The upstream service must not try to modify this cookie. Any changes made to it will be ignored and overwritten by the plugin.
 
+### What about API tokens?
+
+In addition to cookie-based sessions, the plugin also accepts Authentik API tokens passed as a bearer token in the `Authorization` header (`Authorization: Bearer <token>`). This is useful for programmatic clients that can't go through the interactive login flow.
+
+When a request carries a bearer token, the plugin validates it by calling Authentik's `/api/v3/core/users/me/` endpoint instead of the outpost. If the token is valid, the user details (`pk`, `username`, `email` and `groups`) are forwarded upstream using the same `X-Authentik-*` headers as the cookie flow (`X-Authentik-Uid`, `X-Authentik-Username`, `X-Authentik-Email` and `X-Authentik-Groups`, with groups joined by `|`). A request with an invalid or expired token is treated as unauthenticated. When no bearer token is present, the plugin uses the regular cookie-based outpost flow.
+
+Token validations are cached using the same mechanism and `cacheDuration` as cookie sessions, keyed by the token, so repeated requests with the same token don't overload Authentik.
+
 ### Why not just use `forwardAuth`?
 
 Traefik's built-in `forwardAuth` middleware is flexible, but that also means more setup and more room for mistakes. This plugin is made specifically for Authentik, so there is no need to write custom routes, tweak headers, or fight with cookie issues.

--- a/internal/authentik/client.go
+++ b/internal/authentik/client.go
@@ -30,6 +30,11 @@ func NewClient(context context.Context, client *http.Client, config *Config) (*C
 }
 
 func (c *Client) Check(meta *RequestMeta) (*ResponseMeta, error) {
+	// validate bearer token against the authentik api when present
+	if meta.Token != "" {
+		return c.checkToken(meta)
+	}
+
 	// check if s is already cached
 	if s := c.session.Get(meta.Cookies); s != nil {
 		return &ResponseMeta{

--- a/internal/authentik/http.go
+++ b/internal/authentik/http.go
@@ -25,6 +25,17 @@ func GetHeaders(res *http.Response) http.Header {
 	return headers
 }
 
+func GetBearerToken(req *http.Request) string {
+	const prefix = "Bearer "
+
+	auth := req.Header.Get("Authorization")
+	if len(auth) <= len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return ""
+	}
+
+	return strings.TrimSpace(auth[len(prefix):])
+}
+
 func GetCookies(cookier httputil.Cookier) []*http.Cookie {
 	cookies := make([]*http.Cookie, 0, 1)
 

--- a/internal/authentik/meta.go
+++ b/internal/authentik/meta.go
@@ -10,6 +10,7 @@ import (
 type RequestMeta struct {
 	URL     *url.URL
 	Cookies []*http.Cookie
+	Token   string
 }
 
 type ResponseMeta struct {

--- a/internal/authentik/token.go
+++ b/internal/authentik/token.go
@@ -1,0 +1,125 @@
+package authentik
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/xabinapal/traefik-authentik-forward-plugin/internal/session"
+)
+
+const (
+	// TokenUserPath is the Authentik API endpoint used to validate a bearer
+	// token and retrieve the user it belongs to. The /me/ endpoint wraps the
+	// payload under a "user" key.
+	TokenUserPath = "/api/v3/core/users/me/"
+
+	// GroupsSeparator matches the separator Authentik outposts use to join
+	// group names in the X-Authentik-Groups header.
+	GroupsSeparator = "|"
+
+	// tokenCacheCookieName is a synthetic cookie name used to derive a session
+	// cache key from a bearer token, reusing the existing session cache.
+	tokenCacheCookieName = "authentik_token"
+)
+
+// tokenUser mirrors the relevant fields returned by /api/v3/core/users/me/.
+type tokenUser struct {
+	User struct {
+		PK       json.Number `json:"pk"`
+		Username string      `json:"username"`
+		Email    string      `json:"email"`
+		Groups   []struct {
+			Name string `json:"name"`
+		} `json:"groups"`
+	} `json:"user"`
+}
+
+// tokenCacheKey derives a deterministic session cache identifier for a bearer
+// token by reusing the cookie-based session cache. The token value is hashed by
+// the session store, so it is never stored in plaintext.
+func tokenCacheKey(token string) []*http.Cookie {
+	return []*http.Cookie{{Name: tokenCacheCookieName, Value: token}}
+}
+
+// checkToken validates a bearer token against Authentik, caching the result so
+// repeated requests with the same token don't overload the server.
+func (c *Client) checkToken(meta *RequestMeta) (*ResponseMeta, error) {
+	cacheKey := tokenCacheKey(meta.Token)
+
+	// check if the token validation is already cached
+	if s := c.session.Get(cacheKey); s != nil {
+		return &ResponseMeta{
+			URL:     meta.URL,
+			Cached:  true,
+			Session: s,
+		}, nil
+	}
+
+	s, err := c.requestToken(meta.Token)
+	if err != nil {
+		return nil, err
+	}
+
+	// cache token validation result
+	c.session.Set(cacheKey, s)
+
+	return &ResponseMeta{
+		URL:     meta.URL,
+		Cached:  false,
+		Session: s,
+	}, nil
+}
+
+// requestToken calls Authentik to validate the bearer token and builds a
+// session with the same X-Authentik-* headers the outpost would set.
+func (c *Client) requestToken(token string) (*session.Session, error) {
+	akReq, err := http.NewRequest(http.MethodGet, c.config.Address+TokenUserPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	akReq.Header.Set("Authorization", "Bearer "+token)
+
+	res, err := c.client.Do(akReq)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	// any non-2xx response means the token is invalid or expired, mirroring the
+	// reference implementation that treats RestClientResponseException as null
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusMultipleChoices {
+		return &session.Session{IsAuthenticated: false}, nil
+	}
+
+	var body tokenUser
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+
+	user := body.User
+	if user.PK.String() == "" || user.Username == "" {
+		return &session.Session{IsAuthenticated: false}, nil
+	}
+
+	groups := make([]string, 0, len(user.Groups))
+	for _, g := range user.Groups {
+		if g.Name != "" {
+			groups = append(groups, g.Name)
+		}
+	}
+
+	headers := http.Header{}
+	headers.Set(HeaderPrefix+"Uid", user.PK.String())
+	headers.Set(HeaderPrefix+"Username", user.Username)
+	headers.Set(HeaderPrefix+"Email", user.Email)
+	headers.Set(HeaderPrefix+"Groups", strings.Join(groups, GroupsSeparator))
+
+	return &session.Session{
+		IsAuthenticated: true,
+		Headers:         headers,
+		Cookies:         nil,
+	}, nil
+}

--- a/internal/authentik/token_test.go
+++ b/internal/authentik/token_test.go
@@ -1,0 +1,196 @@
+package authentik_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/xabinapal/traefik-authentik-forward-plugin/internal/authentik"
+)
+
+const tokenUserResponse = `{
+	"user": {
+		"pk": 42,
+		"username": "testuser",
+		"email": "user@example.com",
+		"groups": [
+			{"name": "admins"},
+			{"name": "users"}
+		]
+	}
+}`
+
+func tokenRequestMeta(token string) *authentik.RequestMeta {
+	return &authentik.RequestMeta{
+		URL: &url.URL{
+			Scheme: "https",
+			Host:   "example.com",
+			Path:   "/protected",
+		},
+		Cookies: []*http.Cookie{},
+		Token:   token,
+	}
+}
+
+func TestCheckToken(t *testing.T) {
+	t.Run("with valid token", func(t *testing.T) {
+		akCalled := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			akCalled = true
+
+			// check that the api path is used
+			expectedPath := "/api/v3/core/users/me/"
+			if r.URL.Path != expectedPath {
+				t.Fatalf("expected path %s, got %s", expectedPath, r.URL.Path)
+			}
+
+			// check that the bearer token is forwarded
+			expectedAuth := "Bearer test-token"
+			if r.Header.Get("Authorization") != expectedAuth {
+				t.Fatalf("expected authorization %s, got %s", expectedAuth, r.Header.Get("Authorization"))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(tokenUserResponse))
+		}))
+		defer server.Close()
+
+		config := &authentik.Config{Address: server.URL}
+		client, _ := authentik.NewClient(context.Background(), server.Client(), config)
+
+		resMeta, err := client.Check(tokenRequestMeta("test-token"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !akCalled {
+			t.Fatalf("expected authentik server to be called")
+		}
+
+		// check that the request was authenticated
+		if !resMeta.Session.IsAuthenticated {
+			t.Error("expected request to be authenticated")
+		}
+
+		// check that the user data is mapped to authentik headers
+		expectedHeaders := map[string]string{
+			"X-Authentik-Uid":      "42",
+			"X-Authentik-Username": "testuser",
+			"X-Authentik-Email":    "user@example.com",
+			"X-Authentik-Groups":   "admins|users",
+		}
+
+		for k, v := range expectedHeaders {
+			if got := resMeta.Session.Headers.Get(k); got != v {
+				t.Errorf("expected header %s=%s, got %s", k, v, got)
+			}
+		}
+	})
+
+	t.Run("with invalid token", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		config := &authentik.Config{Address: server.URL}
+		client, _ := authentik.NewClient(context.Background(), server.Client(), config)
+
+		resMeta, err := client.Check(tokenRequestMeta("bad-token"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// check that the request was not authenticated
+		if resMeta.Session.IsAuthenticated {
+			t.Error("expected request to be unauthenticated")
+		}
+
+		// check that no authentik headers are set
+		if len(resMeta.Session.Headers) != 0 {
+			t.Errorf("expected 0 headers, got %d", len(resMeta.Session.Headers))
+		}
+	})
+
+	t.Run("with caching", func(t *testing.T) {
+		akCalls := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			akCalls++
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(tokenUserResponse))
+		}))
+		defer server.Close()
+
+		config := &authentik.Config{Address: server.URL, CacheDuration: time.Minute}
+		client, _ := authentik.NewClient(context.Background(), server.Client(), config)
+
+		// first request hits authentik
+		resMeta, err := client.Check(tokenRequestMeta("test-token"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resMeta.Cached {
+			t.Error("expected first request to not be cached")
+		}
+
+		// second request with the same token is served from cache
+		resMeta, err = client.Check(tokenRequestMeta("test-token"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resMeta.Cached {
+			t.Error("expected second request to be cached")
+		}
+
+		// authentik must only be queried once
+		if akCalls != 1 {
+			t.Errorf("expected authentik to be called once, got %d", akCalls)
+		}
+
+		// a different token must not be served from the first token's cache
+		resMeta, err = client.Check(tokenRequestMeta("other-token"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resMeta.Cached {
+			t.Error("expected request with different token to not be cached")
+		}
+		if akCalls != 2 {
+			t.Errorf("expected authentik to be called twice, got %d", akCalls)
+		}
+	})
+}
+
+func TestGetBearerToken(t *testing.T) {
+	cases := []struct {
+		name     string
+		header   string
+		expected string
+	}{
+		{"with bearer token", "Bearer abc123", "abc123"},
+		{"with lowercase scheme", "bearer abc123", "abc123"},
+		{"with surrounding spaces", "Bearer   abc123  ", "abc123"},
+		{"without authorization", "", ""},
+		{"with basic scheme", "Basic dXNlcjpwYXNz", ""},
+		{"with empty token", "Bearer ", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+			if tc.header != "" {
+				req.Header.Set("Authorization", tc.header)
+			}
+
+			if got := authentik.GetBearerToken(req); got != tc.expected {
+				t.Errorf("expected token %q, got %q", tc.expected, got)
+			}
+		})
+	}
+}

--- a/plugin.go
+++ b/plugin.go
@@ -96,6 +96,7 @@ func (p *Plugin) handleRequest(req *http.Request) (*authentik.RequestMeta, error
 	meta := &authentik.RequestMeta{
 		URL:     url,
 		Cookies: authentik.GetCookies(req),
+		Token:   authentik.GetBearerToken(req),
 	}
 
 	// remove authentik headers and cookies in request to upstream


### PR DESCRIPTION
Hello! I'm proposing to add the token based authentication to support non-browser based access. 
This is something also the default Authentik forward-auth is missing, and would otherwise require a separate plugin or additional logic.